### PR TITLE
Добавлен якорь на блок комментариев для кнопки комментариев

### DIFF
--- a/resources/views/post/list.blade.php
+++ b/resources/views/post/list.blade.php
@@ -80,7 +80,7 @@
             <x-like :model="$post"/>
 
             <a class="d-flex align-items-center text-body-secondary text-decoration-none me-4"
-               href="{{ route('post.show', $post) }}">
+               href="{{ route('post.show', [$post, '#comments-frame']) }}">
                 <x-icon path="i.comment"/>
                 @if($post->comments_count > 0)
                     <span class="ms-2">{{ $post->comments_count }}</span>

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -73,7 +73,7 @@
                         <x-like :model="$post"/>
 
                         <a class="d-flex align-items-center text-body-secondary text-decoration-none me-4"
-                           href="{{ route('post.show', $post) }}">
+                           href="{{ route('post.show', [$post, '#comments-frame']) }}">
                             <x-icon path="i.comment"/>
                             <span class="ms-2">{{ $post->comments_count }}</span>
                         </a>


### PR DESCRIPTION
При нажатии на кнопку, я, как пользователь, ожидаю то что меня перекинет к блоку комментариев, чтобы я мог их прочитать или добавить, но сейчас при нажатии меня просто перекидывает вверх (обновляется страница)

В этом PR я добавил якорь на блок с id `comments-frame`, это позволяет переместить фокус страницы на блок с комментариями, без обновления.

Также переход к комментариям работает со страницы списка постов

Демонстрация работы этой фичи:

![chrome-capture-2025-3-3](https://github.com/user-attachments/assets/3396e143-1349-431a-b94c-6141e59c89c0)
