### PR TITLE
Валидация формы поста перед вызовом preview

### DIFF
--- a/resources/js/controllers/post_preview_controller.js
+++ b/resources/js/controllers/post_preview_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['form'];
+
+    validate(event) {
+        if (!this.formTarget.reportValidity()) {
+            // Важно! Остановка всплытия события, включая текущий уровень
+            // Это нужно для того, чтобы не вызывались остальные обработчики
+            event.stopImmediatePropagation();
+        }
+    }
+}

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -6,7 +6,7 @@
             <div class="bg-body-tertiary p-4 p-xl-5 rounded">
                 <div class="col-xxl-8 mx-auto">
 
-                    <form method="post">
+                    <form method="post" data-controller="post-preview" data-post-preview-target="form">
                         <div
                             data-controller="tabs"
                             data-tabs-active-tab-class="bg-body-secondary"
@@ -29,7 +29,7 @@
                                         <button
                                             id="preview"
                                             data-tabs-target="tab"
-                                            data-action="click->tabs#change"
+                                            data-action="click->post-preview#validate click->tabs#change"
                                             type="submit"
                                             formaction="{{  route('post.preview') }}"
                                             class="btn btn-link text-decoration-none  link-body-emphasis"


### PR DESCRIPTION
Реализовал вызов нативной проверки формы, при нажатии на кнопку "Предпросмотр". Если форма невалидна, то никакие другие обработчики вызваны не будут.

@tabuna в issue предложил делать кнопку disabled, но если это сделать, то пользователь, который написал определённое количество абзацев в поле content, может не заметить поле "Заголовок". В этом случае пользователь начнёт тупить и не понимать, почему кнопка неактивна.

Моя реализация решает эту проблему, так как при нажатии на кнопку "Предпросмотр", произойдёт фокус браузером на обязательном поле, которое пользователь пропустил.

Демонстрация работы:

![chrome-capture-2025-3-3](https://github.com/user-attachments/assets/0b4f49d6-2aa3-4498-85c4-d71a9e6aeaf6)

В данной реализации `click->post-preview#validate` обязательно должен стоять перед `click->tabs#change`, иначе последовательность будет нарушена.

Это решает проблему https://github.com/laravelsu/laravel.su/issues/97

