### PR TITLE
Fixed Pastebin link truncation on mobile. Closes #270

### DIFF
--- a/resources/views/pastebin/index.blade.php
+++ b/resources/views/pastebin/index.blade.php
@@ -29,9 +29,9 @@
                     Новый фрагмент
                 </a>
 
-                <div class="d-flex align-items-baseline clipboard ms-auto" data-controller="clipboard"
+                <div class="d-flex ms-md-auto align-items-baseline justify-content-center justify-content-md-end clipboard" data-controller="clipboard"
                      data-clipboard-done-class="done">
-                    <small class="user-select-all me-2 col-6 col-md-auto text-truncate lh-1"
+                    <small class="user-select-all me-2 col-6 col-md-auto text-truncate lh-1 w-auto"
                            data-clipboard-target="source">{{ url()->current() }}</small>
                     <a href="#"
                        data-action="clipboard#copy">


### PR DESCRIPTION
### Fixed link truncation issue on Pastebin mobile view

- Fixed the problem where the URL was getting cut off on smaller screens.
- Added CSS adjustments to ensure the full link is visible on mobile devices.
- Verified that the desktop layout remains unchanged.

Before and after fix:  
<img width="45%" height="auto" alt="Снимок экрана от 2025-07-28 08-05-17" src="https://github.com/user-attachments/assets/fadef2dc-5ced-42ee-ae34-b80ac45a2d1f" /> <img width="45%" height="auto" alt="Снимок экрана от 2025-07-28 08-16-19" src="https://github.com/user-attachments/assets/6c1e35ba-8581-4912-af23-c9c0d2ec028d" />